### PR TITLE
make remote debugging work in my vim 7.4

### DIFF
--- a/autoload/breakpts.vim
+++ b/autoload/breakpts.vim
@@ -1131,17 +1131,20 @@ function! s:ShowRemoteContext() " {{{
     if $LANG =~ "es"
       let str_in_line = 'en la línea'
     else
-      let str_in_line = 'in line'
+      let str_in_line = 'line'
     endif
-
-    exec substitute(context,
+    let name = ''
+    let sr = substitute(context,
           \ '^function \%('.s:FUNC_NAME_PAT.'\.\.\)*\('.s:FUNC_NAME_PAT.
           \ '\), '.str_in_line.' \(\d\+\)$',
-          \ 'let name = "\1" | let lineNo = "\2"', '')
+          \ 'let name = ''\1'' | let lineNo = ''\2''', '')
+    if sr != context
+      exec sr
+    endif
     if name == ''
       exec substitute(context,
             \ '^\([^,]\+\), '.str_in_line.' \(\d\+\)$',
-            \ 'let name = "\1" | let lineNo = "\2"', '')
+            \ 'let name = ''\1'' | let lineNo = ''\2''', '')
       let mode = g:breakpts#BM_SCRIPT
     endif
     if name != ''


### PR DESCRIPTION
-      let str_in_line = 'in line'
+      let str_in_line = 'line'     >>> my vim 7.4 message format is '<script file path>, line xxx'
     endif
-
-    exec substitute(context,
+    let name = ''    >>> 'name' variable  won't be created if the following pattern doesn't match
+    let sr = substitute(context,
           \ '^function \%('.s:FUNC_NAME_PAT.'\.\.\)*\('.s:FUNC_NAME_PAT.
           \ '\), '.str_in_line.' \(\d\+\)$',
-          \ 'let name = "\1" | let lineNo = "\2"', '')
+          \ 'let name = ''\1'' | let lineNo = ''\2''', '')
+    if sr != context       >>> execute the substituted string only if the above pattern matched
+      exec sr
+    endif
     if name == ''
       exec substitute(context,
             \ '^\([^,]\+\), '.str_in_line.' \(\d\+\)$',
-            \ 'let name = "\1" | let lineNo = "\2"', '')
+            \ 'let name = ''\1'' | let lineNo = ''\2''', '') 
>>> replace each double quote with two single quote, because file paths such as "C:\temp\aaa.vim" 
>>> will interpret "\temp" as a tab sign plus "emp" if sourrouded by double qoutes